### PR TITLE
docs: CLAUDE.mdに開発プロセスのベストプラクティスを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,124 @@ GitHubリポジトリの Settings → Branches で以下を設定：
 
 同様の設定を`main`ブランチにも適用します。
 
+## CodeRabbitレビュー対応
+
+### レビュー指摘の確認
+
+```bash
+# PRのレビューコメントを確認
+gh pr view <PR番号> --comments
+
+# APIでコメント詳細を取得
+gh api repos/team-mirai-volunteer/polister/pulls/<PR番号>/comments
+```
+
+### 対応プロセス
+
+1. **レビュー指摘を確認**: 全ての指摘（Major、Minor、Nitpick）を確認
+2. **設計判断が必要な場合**: コメントで説明し`@coderabbitai`メンション
+3. **修正を実施**: コードを修正してコミット
+4. **対応内容を報告**: コメントで修正内容を説明
+
+### 設計判断の文書化
+
+重要な設計判断は以下に記録：
+
+- **コメント**: PRのレビュースレッドで説明
+- **Issue**: 関連Issueを更新して要件を明確化
+- **ドキュメント**: 該当ドキュメントに理由を記載
+
+## Prisma/データベース
+
+### スキーマ配置
+
+- **場所**: `src/infrastructure/database/schema.prisma`（規約で必須）
+- **理由**: Clean Architectureのインフラ層として配置
+
+### 開発フロー
+
+```bash
+# 開発中（スキーマが頻繁に変わる）
+yarn db:push          # スキーマをDBに反映
+yarn db:generate      # Prismaクライアント生成
+yarn db:studio        # データ確認
+
+# 本番デプロイ前（スキーマが安定後）
+npx prisma migrate dev --name description
+npx prisma migrate deploy
+```
+
+### PostGIS空間インデックス
+
+**必須**: location、polygon等の空間カラムには必ずGISTインデックスを設定
+
+```prisma
+model Board {
+  location Unsupported("geography(POINT, 4326)")
+  @@index([location], type: Gist)  // 必須
+}
+```
+
+### 論理削除の設計方針
+
+#### 論理削除を使用するモデル
+
+- **User**: 検証履歴・画像データの保全のため
+- **Board**: 削除履歴の追跡のため
+
+```prisma
+model User {
+  deletedAt DateTime? @map("deleted_at")
+}
+```
+
+#### カスケード削除の判断基準
+
+| データの性質 | カスケード削除 | 例 |
+|------------|--------------|---|
+| 一時的な認証情報 | ✅ 維持 | Account、Session |
+| 現在の設定値 | ✅ 維持 | UserLocation |
+| 永続的な履歴 | ❌ 除去 | Verification、BoardImage |
+
+**理由**: 検証履歴と証拠写真は監査証跡として永続的に保持
+
+## Issue管理
+
+### スコープ管理
+
+- **原則**: 1つのPRは1つのIssueに集中
+- **スコープ外の変更**: 別Issueを作成して分離
+- **例**: データベース設計PRに図のズーム機能を含めない
+
+### Issueの更新
+
+```bash
+# Issueの内容を更新
+gh issue edit <番号> --body "$(cat <<'EOF'
+更新内容...
+EOF
+)"
+```
+
+設計判断や要件変更があった場合は、Issueを更新して記録します。
+
+## ドキュメント作成
+
+### 標準構成
+
+技術ドキュメントには以下を含める：
+
+1. **概要図**: Mermaid ER図、アーキテクチャ図
+2. **詳細説明**: テーブル定義、カラム説明
+3. **使用例**: コードサンプル、クエリ例
+4. **トラブルシューティング**: よくある問題と解決方法
+
+### Mermaid図
+
+- テーブル構造: ER図
+- フロー: flowchart、sequenceDiagram
+- 状態遷移: stateDiagram
+
 ## プロジェクト概要
 
 これは TypeScript サポートを持つ Next.js 15.5.4 アプリケーションで、React 19.1.0 を使用しています。パッケージ管理には Yarn を使用し、より高速な開発ビルドのために Turbopack を含んでいます。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,28 @@
 
 - **ターゲットブランチ**: `develop`
 
+### PRマージ前の最終確認
+
+Pull Requestを作成する前に、以下を必ず確認：
+
+```bash
+# 全チェックを実行
+yarn validate
+
+# 結果確認
+# ✅ lint: エラーなし
+# ✅ typecheck: エラーなし
+# ✅ format:check: フォーマット済み
+```
+
+**マージ前チェックリスト**:
+
+- [ ] `yarn validate`を実行して全て通過
+- [ ] CIチェックが全て通過（ESLint、TypeScript、Prettier）
+- [ ] CodeRabbitのレビュー指摘に対応済み
+- [ ] CLAチェックボックスにチェック済み
+- [ ] スコープ外の変更が含まれていないか確認
+
 ## コード品質チェック
 
 - **実行ディレクトリ**: 必ずプロジェクトルート（`/Users/seiichiro/apps/team-mirai/polister`）で実行
@@ -170,11 +192,11 @@ model User {
 
 #### カスケード削除の判断基準
 
-| データの性質 | カスケード削除 | 例 |
-|------------|--------------|---|
-| 一時的な認証情報 | ✅ 維持 | Account、Session |
-| 現在の設定値 | ✅ 維持 | UserLocation |
-| 永続的な履歴 | ❌ 除去 | Verification、BoardImage |
+| データの性質     | カスケード削除 | 例                       |
+| ---------------- | -------------- | ------------------------ |
+| 一時的な認証情報 | ✅ 維持        | Account、Session         |
+| 現在の設定値     | ✅ 維持        | UserLocation             |
+| 永続的な履歴     | ❌ 除去        | Verification、BoardImage |
 
 **理由**: 検証履歴と証拠写真は監査証跡として永続的に保持
 


### PR DESCRIPTION
## 変更の概要

これまでの開発で得られた知見をCLAUDE.mdに文書化しました。

## 変更の背景

Issue #13の開発プロセスで得られたベストプラクティスを次の開発にも活かすため。

## 関連Issue

なし（ドキュメント改善）

## 変更内容

- [x] CodeRabbitレビュー対応プロセス
  - レビュー指摘の確認方法（gh cli）
  - 設計判断の説明とメンション方法
  - 対応内容の報告手順
- [x] Prisma/データベースのベストプラクティス
  - スキーマ配置ルール（`src/infrastructure/database/schema.prisma`）
  - 開発フロー（`db:push` vs マイグレーション）
  - PostGIS空間インデックス（GIST）の必須設定
  - 論理削除の設計方針
  - カスケード削除の判断基準（一時的/設定値/履歴）
- [x] Issue管理のベストプラクティス
  - スコープ外の変更は別Issueに分離
  - 設計判断や要件変更はIssue更新で記録
- [x] ドキュメント作成の標準構成
  - 概要図、詳細説明、使用例、トラブルシューティングの4点セット
  - Mermaid図の活用方法

## テスト

- [x] lint/typecheckの実行
- [x] formatの実行

## CLAへの同意

- [x] [CLA](https://github.com/team-mirai-volunteer/polister/blob/develop/CLA.md)の内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- ドキュメント
  - レビュー対応ガイドラインを拡充し、PRコメント対応フロー、設計判断の記録方法、Issue運用、DB/スキーマ運用方針、PostGISインデックス要件、論理削除／カスケード削除ポリシー、図式化（Mermaid等）の標準、プロジェクト概要と開発コマンドの解説を追加。開発プロセスの一貫性と参照性を向上。エンドユーザー向けの機能変更はなし。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->