### PR TITLE
feat: AppBarと一覧ページのレイアウトを最適化

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,7 +62,7 @@ export default function RootLayout({
                 component="main"
                 sx={{
                   flexGrow: 1,
-                  pt: { xs: 10, md: 12 },
+                  pt: { xs: 7, md: 9 },
                 }}
               >
                 {children}

--- a/src/app/municipalities/page.tsx
+++ b/src/app/municipalities/page.tsx
@@ -12,7 +12,7 @@ import {
   type MunicipalityFilterOperator,
 } from "@/features/municipality/domain/repositories/IMunicipalityRepository";
 import { MunicipalityDataGrid } from "@/features/municipality/ui/components/MunicipalityDataGrid";
-import { Container, Typography } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 
 interface PageProps {
   searchParams: Promise<{
@@ -83,26 +83,56 @@ export default async function MunicipalitiesPage({ searchParams }: PageProps) {
   });
 
   return (
-    <Container maxWidth="lg" sx={{ py: 3 }}>
-      <Typography variant="h4" sx={{ mb: 3 }}>
-        自治体一覧
-      </Typography>
+    <Container
+      maxWidth="lg"
+      sx={{
+        py: 3,
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+        overflow: "hidden",
+        height: {
+          xs: "calc(100vh - 56px)",
+          md: "calc(100vh - 72px)",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          flexWrap: { xs: "wrap", sm: "nowrap" },
+          gap: 1,
+        }}
+      >
+        <Typography variant="h4">自治体一覧</Typography>
+        <Typography variant="body2" color="text.secondary">
+          全 {data.total} 件
+        </Typography>
+      </Box>
 
-      <Typography variant="body2" sx={{ mb: 2 }}>
-        全 {data.total} 件
-      </Typography>
-
-      <MunicipalityDataGrid
-        municipalities={data.municipalities}
-        total={data.total}
-        page={page}
-        pageSize={limit}
-        sortField={normalizedSortField}
-        sortOrder={sortOrder}
-        filterField={normalizedFilterField}
-        filterOperator={normalizedFilterOperator}
-        filterValue={filterValue}
-      />
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          display: "flex",
+          width: "100%",
+          overflow: "hidden",
+        }}
+      >
+        <MunicipalityDataGrid
+          municipalities={data.municipalities}
+          total={data.total}
+          page={page}
+          pageSize={limit}
+          sortField={normalizedSortField}
+          sortOrder={sortOrder}
+          filterField={normalizedFilterField}
+          filterOperator={normalizedFilterOperator}
+          filterValue={filterValue}
+        />
+      </Box>
     </Container>
   );
 }

--- a/src/app/municipalities/page.tsx
+++ b/src/app/municipalities/page.tsx
@@ -12,7 +12,7 @@ import {
   type MunicipalityFilterOperator,
 } from "@/features/municipality/domain/repositories/IMunicipalityRepository";
 import { MunicipalityDataGrid } from "@/features/municipality/ui/components/MunicipalityDataGrid";
-import { Box, Container, Typography } from "@mui/material";
+import { ListPageLayout } from "@/shared/ui/components/layout/ListPageLayout";
 
 interface PageProps {
   searchParams: Promise<{
@@ -83,56 +83,18 @@ export default async function MunicipalitiesPage({ searchParams }: PageProps) {
   });
 
   return (
-    <Container
-      maxWidth="lg"
-      sx={{
-        py: 3,
-        display: "flex",
-        flexDirection: "column",
-        gap: 2,
-        overflow: "hidden",
-        height: {
-          xs: "calc(100vh - 56px)",
-          md: "calc(100vh - 72px)",
-        },
-      }}
-    >
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "baseline",
-          justifyContent: "space-between",
-          flexWrap: { xs: "wrap", sm: "nowrap" },
-          gap: 1,
-        }}
-      >
-        <Typography variant="h4">自治体一覧</Typography>
-        <Typography variant="body2" color="text.secondary">
-          全 {data.total} 件
-        </Typography>
-      </Box>
-
-      <Box
-        sx={{
-          flex: 1,
-          minHeight: 0,
-          display: "flex",
-          width: "100%",
-          overflow: "hidden",
-        }}
-      >
-        <MunicipalityDataGrid
-          municipalities={data.municipalities}
-          total={data.total}
-          page={page}
-          pageSize={limit}
-          sortField={normalizedSortField}
-          sortOrder={sortOrder}
-          filterField={normalizedFilterField}
-          filterOperator={normalizedFilterOperator}
-          filterValue={filterValue}
-        />
-      </Box>
-    </Container>
+    <ListPageLayout title="自治体一覧" total={data.total}>
+      <MunicipalityDataGrid
+        municipalities={data.municipalities}
+        total={data.total}
+        page={page}
+        pageSize={limit}
+        sortField={normalizedSortField}
+        sortOrder={sortOrder}
+        filterField={normalizedFilterField}
+        filterOperator={normalizedFilterOperator}
+        filterValue={filterValue}
+      />
+    </ListPageLayout>
   );
 }

--- a/src/app/prefectures/page.tsx
+++ b/src/app/prefectures/page.tsx
@@ -10,7 +10,8 @@ import {
   type PrefectureFilterOperator,
 } from "@/features/prefecture/domain/repositories/IPrefectureRepository";
 import { PrefectureDataGrid } from "@/features/prefecture/ui/components/PrefectureDataGrid";
-import { Box, Container, Typography } from "@mui/material";
+import { ListPageLayout } from "@/shared/ui/components/layout/ListPageLayout";
+import { Container, Typography } from "@mui/material";
 
 interface PrefecturesPageProps {
   searchParams: Promise<{
@@ -66,53 +67,16 @@ export default async function PrefecturesPage({
     });
 
     return (
-      <Container
-        maxWidth="lg"
-        sx={{
-          py: 3,
-          display: "flex",
-          flexDirection: "column",
-          gap: 2,
-          overflow: "hidden",
-          height: {
-            xs: "calc(100vh - 56px)",
-            md: "calc(100vh - 72px)",
-          },
-        }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "baseline",
-            justifyContent: "space-between",
-            flexWrap: { xs: "wrap", sm: "nowrap" },
-            gap: 1,
-          }}
-        >
-          <Typography variant="h4">都道府県一覧</Typography>
-          <Typography variant="body2" color="text.secondary">
-            全 {prefectures.length} 件
-          </Typography>
-        </Box>
-        <Box
-          sx={{
-            flex: 1,
-            minHeight: 0,
-            display: "flex",
-            width: "100%",
-            overflow: "hidden",
-          }}
-        >
-          <PrefectureDataGrid
-            prefectures={prefectures}
-            sortField={normalizedSortField}
-            sortOrder={sortOrder}
-            filterField={normalizedFilterField}
-            filterOperator={normalizedFilterOperator}
-            filterValue={filterValue}
-          />
-        </Box>
-      </Container>
+      <ListPageLayout title="都道府県一覧" total={prefectures.length}>
+        <PrefectureDataGrid
+          prefectures={prefectures}
+          sortField={normalizedSortField}
+          sortOrder={sortOrder}
+          filterField={normalizedFilterField}
+          filterOperator={normalizedFilterOperator}
+          filterValue={filterValue}
+        />
+      </ListPageLayout>
     );
   } catch (error) {
     console.error("failed to load prefectures", error);

--- a/src/app/prefectures/page.tsx
+++ b/src/app/prefectures/page.tsx
@@ -10,7 +10,7 @@ import {
   type PrefectureFilterOperator,
 } from "@/features/prefecture/domain/repositories/IPrefectureRepository";
 import { PrefectureDataGrid } from "@/features/prefecture/ui/components/PrefectureDataGrid";
-import { Container, Typography } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 
 interface PrefecturesPageProps {
   searchParams: Promise<{
@@ -66,23 +66,52 @@ export default async function PrefecturesPage({
     });
 
     return (
-      <Container maxWidth="lg" sx={{ py: 3 }}>
-        <Typography variant="h4" sx={{ mb: 3 }}>
-          都道府県一覧
-        </Typography>
-
-        <Typography variant="body2" sx={{ mb: 2 }}>
-          全 {prefectures.length} 件
-        </Typography>
-
-        <PrefectureDataGrid
-          prefectures={prefectures}
-          sortField={normalizedSortField}
-          sortOrder={sortOrder}
-          filterField={normalizedFilterField}
-          filterOperator={normalizedFilterOperator}
-          filterValue={filterValue}
-        />
+      <Container
+        maxWidth="lg"
+        sx={{
+          py: 3,
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          overflow: "hidden",
+          height: {
+            xs: "calc(100vh - 56px)",
+            md: "calc(100vh - 72px)",
+          },
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            flexWrap: { xs: "wrap", sm: "nowrap" },
+            gap: 1,
+          }}
+        >
+          <Typography variant="h4">都道府県一覧</Typography>
+          <Typography variant="body2" color="text.secondary">
+            全 {prefectures.length} 件
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            display: "flex",
+            width: "100%",
+            overflow: "hidden",
+          }}
+        >
+          <PrefectureDataGrid
+            prefectures={prefectures}
+            sortField={normalizedSortField}
+            sortOrder={sortOrder}
+            filterField={normalizedFilterField}
+            filterOperator={normalizedFilterOperator}
+            filterValue={filterValue}
+          />
+        </Box>
       </Container>
     );
   } catch (error) {

--- a/src/features/municipality/ui/components/MunicipalityDataGrid.tsx
+++ b/src/features/municipality/ui/components/MunicipalityDataGrid.tsx
@@ -483,6 +483,9 @@ export function MunicipalityDataGrid({
       pageSizeOptions={[10, 25, 50, 100]}
       disableRowSelectionOnClick
       sx={{
+        flex: 1,
+        height: "100%",
+        width: "100%",
         "& .MuiDataGrid-row": {
           cursor: "pointer",
         },

--- a/src/features/prefecture/ui/components/PrefectureDataGrid.tsx
+++ b/src/features/prefecture/ui/components/PrefectureDataGrid.tsx
@@ -379,7 +379,6 @@ export function PrefectureDataGrid({
       filterMode="server"
       sortModel={sortModel}
       filterModel={filterModel}
-      autoHeight
       pageSizeOptions={[10, 25, 50]}
       initialState={{
         pagination: {
@@ -405,6 +404,9 @@ export function PrefectureDataGrid({
         },
       }}
       sx={{
+        flex: 1,
+        height: "100%",
+        width: "100%",
         "& .MuiDataGrid-row": {
           cursor: "pointer",
         },

--- a/src/shared/constants/layout.ts
+++ b/src/shared/constants/layout.ts
@@ -1,0 +1,32 @@
+export const APP_BAR_HEIGHT = {
+  xs: 56,
+  md: 72,
+} as const;
+
+export const LIST_PAGE_CONTAINER_SX = {
+  py: 3,
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: 2,
+  overflow: "hidden",
+  height: {
+    xs: `calc(100vh - ${APP_BAR_HEIGHT.xs}px)` as const,
+    md: `calc(100vh - ${APP_BAR_HEIGHT.md}px)` as const,
+  },
+};
+
+export const LIST_PAGE_HEADER_SX = {
+  display: "flex",
+  alignItems: "baseline",
+  justifyContent: "space-between",
+  flexWrap: { xs: "wrap", sm: "nowrap" } as const,
+  gap: 1,
+};
+
+export const LIST_PAGE_BODY_SX = {
+  flex: 1,
+  minHeight: 0,
+  display: "flex",
+  width: "100%",
+  overflow: "hidden",
+};

--- a/src/shared/ui/components/layout/AppBar.tsx
+++ b/src/shared/ui/components/layout/AppBar.tsx
@@ -23,6 +23,7 @@ export function AppBar() {
   const navItems = [
     { label: "ホーム", path: "/" },
     { label: "自治体一覧", path: "/municipalities" },
+    { label: "都道府県一覧", path: "/prefectures" },
   ];
 
   const docsUrl =
@@ -31,7 +32,13 @@ export function AppBar() {
 
   return (
     <MuiAppBar position="fixed">
-      <Toolbar disableGutters>
+      <Toolbar
+        disableGutters
+        sx={{
+          minHeight: { xs: 56, md: 72 },
+          px: { xs: 2, md: 0 },
+        }}
+      >
         <Container
           maxWidth="lg"
           sx={{
@@ -44,20 +51,20 @@ export function AppBar() {
           <Link href="/" style={{ textDecoration: "none", color: "inherit" }}>
             <Stack
               direction="row"
-              spacing={1.5}
+              spacing={1}
               alignItems="center"
               sx={{ cursor: "pointer" }}
             >
               <Box
                 aria-hidden="true"
                 sx={{
-                  width: 32,
-                  height: 32,
+                  width: 28,
+                  height: 28,
                   borderRadius: 1,
                   display: "grid",
                   placeItems: "center",
                   fontWeight: 700,
-                  fontSize: "0.85rem",
+                  fontSize: "0.75rem",
                   backgroundColor: (theme) =>
                     alpha(theme.palette.primary.main, 0.12),
                   color: "secondary.main",
@@ -65,24 +72,17 @@ export function AppBar() {
               >
                 P
               </Box>
-              <Box>
-                <Typography variant="h6" sx={{ letterSpacing: "0.08em" }}>
-                  POLISTER
-                </Typography>
-                <Typography
-                  variant="subtitle2"
-                  sx={{
-                    // デザイン仕様により、subtitle2のデフォルトサイズをオーバーライド
-                    fontSize: "1rem",
-                  }}
-                >
-                  ポスター掲示板データ基盤
-                </Typography>
-              </Box>
+              <Typography
+                variant="h6"
+                component="span"
+                sx={{ letterSpacing: "0.12em", fontSize: "1.1rem" }}
+              >
+                POLISTER
+              </Typography>
             </Stack>
           </Link>
 
-          <Stack direction="row" spacing={1} alignItems="center">
+          <Stack direction="row" spacing={0.5} alignItems="center">
             {navItems.map((item) => {
               const isActive =
                 item.path === "/"
@@ -94,10 +94,29 @@ export function AppBar() {
                   key={item.path}
                   component={Link}
                   href={item.path}
-                  variant={isActive ? "contained" : "text"}
-                  color={isActive ? "secondary" : "inherit"}
+                  variant="text"
+                  color="inherit"
                   aria-current={isActive ? "page" : undefined}
-                  sx={{ fontWeight: 600 }}
+                  size="small"
+                  sx={{
+                    fontWeight: 600,
+                    ...(isActive
+                      ? {
+                          color: (theme) => theme.palette.primary.main,
+                          backgroundColor: (theme) =>
+                            theme.palette.primary.contrastText,
+                          "&:hover": {
+                            backgroundColor: (theme) =>
+                              alpha(theme.palette.primary.contrastText, 0.9),
+                          },
+                        }
+                      : {
+                          "&:hover": {
+                            backgroundColor: (theme) =>
+                              alpha(theme.palette.primary.contrastText, 0.12),
+                          },
+                        }),
+                  }}
                 >
                   {item.label}
                 </Button>

--- a/src/shared/ui/components/layout/AppBar.tsx
+++ b/src/shared/ui/components/layout/AppBar.tsx
@@ -17,6 +17,8 @@ import { alpha } from "@mui/material/styles";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import { APP_BAR_HEIGHT } from "@/shared/constants/layout";
+
 export function AppBar() {
   const pathname = usePathname();
 
@@ -35,7 +37,7 @@ export function AppBar() {
       <Toolbar
         disableGutters
         sx={{
-          minHeight: { xs: 56, md: 72 },
+          minHeight: { xs: APP_BAR_HEIGHT.xs, md: APP_BAR_HEIGHT.md },
           px: { xs: 2, md: 0 },
         }}
       >

--- a/src/shared/ui/components/layout/ListPageLayout.tsx
+++ b/src/shared/ui/components/layout/ListPageLayout.tsx
@@ -1,0 +1,32 @@
+import { Box, Container, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+
+import {
+  LIST_PAGE_BODY_SX,
+  LIST_PAGE_CONTAINER_SX,
+  LIST_PAGE_HEADER_SX,
+} from "@/shared/constants/layout";
+
+interface ListPageLayoutProps {
+  title: string;
+  total: number;
+  children: ReactNode;
+}
+
+export function ListPageLayout({
+  title,
+  total,
+  children,
+}: ListPageLayoutProps) {
+  return (
+    <Container maxWidth="lg" sx={LIST_PAGE_CONTAINER_SX}>
+      <Box sx={LIST_PAGE_HEADER_SX}>
+        <Typography variant="h4">{title}</Typography>
+        <Typography variant="body2" color="text.secondary">
+          全 {total} 件
+        </Typography>
+      </Box>
+      <Box sx={LIST_PAGE_BODY_SX}>{children}</Box>
+    </Container>
+  );
+}


### PR DESCRIPTION
## 概要
- AppBarのブランド表示とナビゲーションの強調色を見直し、高さをコンパクト化
- 自治体・都道府県一覧のコンテナをフレックスレイアウトに更新し、画面内スクロールで完結する構造を統一
- DataGridのサイズ指定を調整して親要素いっぱいに表示されるように改善
- closes #N/A

## テスト
- yarn validate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ナビゲーションに「都道府県一覧」メニュー項目を追加

* **Style**
  * 市区町村ページと都道府県ページのレイアウトを改善
  * グリッドコンポーネントの表示サイズを最適化
  * ナビゲーションバーのスペーシングを調整
  * ヘッダー領域のレイアウトを統一
  * メインコンテンツの余白を調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->