### PR TITLE
feat: NextAuth.js認証基盤（Credentials認証）を実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,10 @@ REDIS_URL="redis://localhost:6379"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="your-secret-key-here-change-in-production"
 
-# Google OAuth
-GOOGLE_CLIENT_ID="your-google-client-id"
-GOOGLE_CLIENT_SECRET="your-google-client-secret"
+# Admin Bootstrap (optional; used by `yarn user:create-admin`)
+# ADMIN_EMAIL="admin@example.com"
+# ADMIN_PASSWORD="change-me"
+# ADMIN_NAME="Polister 管理者"
 
 # Mapbox
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN="your-mapbox-access-token"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ PORT=3100 yarn docs:dev
 - アプリケーション: <http://localhost:3000>
 - ドキュメント: <http://localhost:3100（`PORT=3100> yarn docs:dev` で起動）
 
+### 環境変数
+
+`.env.example` をコピーして `.env` を作成し、以下の値を設定してください：
+
+- `NEXTAUTH_URL`: ローカル開発では `http://localhost:3000` を指定
+- `NEXTAUTH_SECRET`: `openssl rand -base64 32` などで生成したランダム文字列
+- 初期管理者作成時は `ADMIN_EMAIL` / `ADMIN_PASSWORD`（任意で `ADMIN_NAME`）をセットして `yarn user:create-admin` を実行
+
+サインインはメールアドレスとパスワードで行います。Google OAuth 連携は今後の実装予定です。
+
+```bash
+# 初期管理者アカウントの作成例
+ADMIN_EMAIL="admin@example.com" \
+ADMIN_PASSWORD="change-me" \
+yarn user:create-admin
+```
+
 ## 📚 ドキュメント
 
 詳細なドキュメントは以下で公開しています：

--- a/docs/docs/plan/23_user-auth-nextauth.md
+++ b/docs/docs/plan/23_user-auth-nextauth.md
@@ -1,0 +1,44 @@
+# Issue #23 ユーザー認証基盤（NextAuth.js） 実行計画
+
+## 全体像
+
+- 目的: NextAuth.js v5 をベースに、メールアドレス＋パスワードによる認証を実装し、初期管理者アカウントを安全に運用できる基盤を整備する。
+- 背景: MVP フェーズではまず内部運用を優先するため、Google OAuth 連携よりも手元で管理しやすい Credentials 認証が求められた。
+- スコープ: NextAuth.js 設定の再構成（Credentials プロバイダー化）、パスワードハッシュ管理、初期管理者作成スクリプト、ログイン UI、認証ミドルウェア、環境変数と手順ドキュメント更新。
+
+## 進捗状況（チェックリスト）
+
+- [x] NextAuth.js 基盤導入（JWT セッション化）
+- [x] Credentials 認証への転換（Prisma 連携／パスワードハッシュ）
+- [x] 初期管理者アカウント作成フローの実装
+- [x] 認証ミドルウェアの Edge 対応検証（Credentials 版）
+- [x] ログイン画面（フォーム）実装
+- [x] 環境変数・運用手順ドキュメント更新
+- [x] `yarn validate` の再実行
+- [x] 影響範囲に応じたユニットテスト実行
+- [x] JWTSessionError 修正（NEXTAUTH_SECRET フォールバック処理）
+
+## 発見と驚き
+
+- 現行コードベースに NextAuth.js 関連の設定は存在しない（`.env.example` には `NEXTAUTH_URL` / `NEXTAUTH_SECRET` のみが存在）。
+- `AppShell` 配下の `AppBar` ではダミーユーザー情報を直接渡しており、サインイン/サインアウトは未実装。
+- DI コンテナには認証関連の依存関係登録がなく、Prisma のみがグローバル管理されている。
+- BoardImport 系サーバーアクションは認証チェックを持たずに公開されていたため、サーバー側でもセッション必須にする方針を採用。
+- Next.js ミドルウェアは Edge Runtime 上で動作するため、Prisma/DI 依存を直接持たない JWT セッション構成に切り替える必要があった。
+- 認証方式を Google OAuth から Credentials (Email + Password) へ切り替える要望を受け、パスワードハッシュ管理と初期管理者導線が必要。
+- `NEXTAUTH_SECRET` が `undefined` の場合に JWTSessionError が発生する問題を発見。開発環境用のフォールバック処理を追加し、本番環境では必須とする設計に変更。
+
+## 決定ログ（日時と理由）
+
+- 2025-10-31 10:04 JST: Issue #23 対応としてブランチ `feature/#23_user-auth-nextauth` を作成（develop 起点）。
+- 2025-10-31 10:13 JST: BoardImport 関連のサーバーアクション実行時に `requireAuth` を強制し、未認証アクセスを防止する。
+- 2025-10-31 10:22 JST: ミドルウェアの Edge Runtime 制約に合わせてセッション戦略を JWT 化し、Edge 用軽量設定とサーバー用 Prisma Adapter 設定を分離。
+- 2025-10-31 10:22 JST: `yarn validate`（typecheck/lint/format:check/test:coverage/test:e2e）を完走し、全テストが成功。
+- 2025-10-31 10:30 JST: Google OAuth を後回しにし、Credentials 認証を優先する方針へ転換。
+- 2025-10-31 10:45 JST: Prisma スキーマに `passwordHash` を追加し、Credentials プロバイダー＋ログインフォーム＋管理者作成スクリプトを実装。
+- 2025-10-31 10:47 JST: `yarn validate` を再実行し、Lint/Typecheck/Jest/Playwright が全て成功。
+- 2025-11-09 JST: JWTSessionError の原因を調査し、`NEXTAUTH_SECRET` が未設定の場合のフォールバック処理を実装。開発環境ではデフォルト値を使用し警告を表示、本番環境ではエラーを投げるように修正（src/shared/lib/auth/config.ts）。
+
+## To-Do
+
+- フォローアップ事項は現在なし（次フェーズで追加要件があれば更新）。

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "municipalities:sync": "tsx src/scripts/sync-municipalities.ts",
     "docs:dev": "cd docs && yarn start",
     "docs:build": "cd docs && yarn build",
-    "docs:serve": "cd docs && yarn serve"
+    "docs:serve": "cd docs && yarn serve",
+    "user:create-admin": "tsx src/scripts/create-admin-user.ts"
   },
   "dependencies": {
     "@emotion/cache": "^11.14.0",
@@ -39,6 +40,7 @@
     "@prisma/client": "6.16.2",
     "@turf/turf": "^7.2.0",
     "adm-zip": "^0.5.16",
+    "bcryptjs": "^3.0.2",
     "csv-parse": "^6.1.0",
     "dbffile": "^1.12.0",
     "dotenv": "^17.2.3",
@@ -46,6 +48,7 @@
     "iconv-lite": "^0.7.0",
     "mapbox-gl": "^3.15.0",
     "next": "15.5.4",
+    "next-auth": "5.0.0-beta.30",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-map-gl": "^8.1.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,6 +167,7 @@ model User {
   name              String?
   slackName         String?   @map("slack_name")
   image             String?
+  passwordHash      String?   @map("password_hash") @db.Text
   role              UserRole  @default(VIEWER)
   trustScore        Float     @default(0.0) @map("trust_score")
   verificationCount Int       @default(0) @map("verification_count")

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,4 @@
+import { handlers } from "@/shared/lib/auth";
+
+export const GET = handlers.GET;
+export const POST = handlers.POST;

--- a/src/app/auth/signin/SignInForm.tsx
+++ b/src/app/auth/signin/SignInForm.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import LoginIcon from "@mui/icons-material/Login";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+
+const ERROR_MESSAGES: Record<string, string> = {
+  CredentialsSignin: "メールアドレスまたはパスワードが正しくありません。",
+  default: "サインインに失敗しました。入力内容を確認してください。",
+};
+
+interface SignInFormProps {
+  callbackUrl: string;
+  initialError?: string | null;
+}
+
+export function SignInForm({ callbackUrl, initialError }: SignInFormProps) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(
+    initialError
+      ? (ERROR_MESSAGES[initialError] ?? ERROR_MESSAGES.default)
+      : null
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      setIsSubmitting(true);
+      setError(null);
+
+      try {
+        const result = await signIn("credentials", {
+          email,
+          password,
+          redirect: false,
+          callbackUrl,
+        });
+
+        if (result?.error) {
+          setError(ERROR_MESSAGES[result.error] ?? ERROR_MESSAGES.default);
+          return;
+        }
+
+        const destination = result?.url ?? callbackUrl ?? "/";
+        router.push(destination);
+        router.refresh();
+      } catch (submissionError) {
+        console.error("Sign-in failed", submissionError);
+        setError(ERROR_MESSAGES.default);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [callbackUrl, email, password, router]
+  );
+
+  return (
+    <Box
+      component="section"
+      sx={{
+        maxWidth: 420,
+        mx: "auto",
+        mt: { xs: 6, md: 10 },
+        p: { xs: 3, md: 4 },
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: "divider",
+        backgroundColor: "background.paper",
+        boxShadow: (theme) => theme.shadows[2],
+      }}
+    >
+      <Stack spacing={3} component="form" onSubmit={handleSubmit}>
+        <div>
+          <Typography component="h1" variant="h5" fontWeight={700} gutterBottom>
+            サインイン
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            管理者から付与されたメールアドレスとパスワードを入力してください。
+          </Typography>
+        </div>
+
+        {error ? <Alert severity="error">{error}</Alert> : null}
+
+        <TextField
+          label="メールアドレス"
+          type="email"
+          name="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          autoComplete="email"
+          required
+          fullWidth
+        />
+
+        <TextField
+          label="パスワード"
+          type="password"
+          name="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          autoComplete="current-password"
+          required
+          fullWidth
+        />
+
+        <Button
+          type="submit"
+          variant="contained"
+          size="large"
+          endIcon={<LoginIcon />}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "サインイン中..." : "サインイン"}
+        </Button>
+
+        <Typography variant="body2" color="text.secondary" textAlign="center">
+          パスワードを忘れた場合は管理者に連絡してください。
+        </Typography>
+
+        <Typography variant="body2" textAlign="center">
+          <Link href="/" underline="hover">
+            ホームに戻る
+          </Link>
+        </Typography>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+
+import { SignInForm } from "./SignInForm";
+
+export const metadata: Metadata = {
+  title: "サインイン | Polister",
+};
+
+interface SignInPageProps {
+  searchParams?: Promise<{
+    callbackUrl?: string;
+    error?: string;
+  }>;
+}
+
+const getSafeCallbackUrl = (value?: string): string => {
+  if (!value) {
+    return "/";
+  }
+
+  try {
+    const decoded = decodeURIComponent(value);
+    if (decoded.startsWith("/")) {
+      return decoded;
+    }
+    const url = new URL(decoded);
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return "/";
+  }
+};
+
+export default async function SignInPage({ searchParams }: SignInPageProps) {
+  const resolved = searchParams ? await searchParams : undefined;
+  const callbackUrl = getSafeCallbackUrl(resolved?.callbackUrl);
+  const error = resolved?.error ?? null;
+
+  return <SignInForm callbackUrl={callbackUrl} initialError={error} />;
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -21,19 +21,13 @@ const getSafeCallbackUrl = (value?: string): string => {
   try {
     const decoded = decodeURIComponent(value);
 
-    // プロトコル相対パス（//evil.com）やホスト指定（/\）を拒否
-    if (decoded.startsWith("//") || decoded.startsWith("/\\")) {
+    // 単一スラッシュで始まるパスのみ許可（絶対URLやホスト指定を拒否）
+    // 正規表現: /で始まり、2文字目が/でもバックスラッシュでもない
+    if (!/^\/[^/\\]/.test(decoded)) {
       return "/";
     }
 
-    // 単一スラッシュで始まるパスのみ許可
-    if (decoded.startsWith("/")) {
-      return decoded;
-    }
-
-    // 絶対URLの場合はパス部分のみ抽出
-    const url = new URL(decoded);
-    return url.pathname + url.search + url.hash;
+    return decoded;
   } catch {
     return "/";
   }

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -20,9 +20,18 @@ const getSafeCallbackUrl = (value?: string): string => {
 
   try {
     const decoded = decodeURIComponent(value);
+
+    // プロトコル相対パス（//evil.com）やホスト指定（/\）を拒否
+    if (decoded.startsWith("//") || decoded.startsWith("/\\")) {
+      return "/";
+    }
+
+    // 単一スラッシュで始まるパスのみ許可
     if (decoded.startsWith("/")) {
       return decoded;
     }
+
+    // 絶対URLの場合はパス部分のみ抽出
     const url = new URL(decoded);
     return url.pathname + url.search + url.hash;
   } catch {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,10 @@ import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Noto_Sans_JP } from "next/font/google";
 
+import { auth } from "@/shared/lib/auth";
 import { setupDI } from "@/shared/lib/di";
 import { AppShell } from "@/shared/ui/components/layout/AppShell";
+import { AuthSessionProvider } from "@/shared/ui/providers/AuthSessionProvider";
 import { ColorModeProvider } from "@/shared/ui/providers/ColorModeProvider";
 
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -36,17 +38,21 @@ export const metadata: Metadata = {
   description: "Polisterプロジェクト",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const session = await auth();
+
   return (
     <html lang="ja" className={notoSansJP.variable} suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <AppRouterCacheProvider>
           <ColorModeProvider>
-            <AppShell>{children}</AppShell>
+            <AuthSessionProvider session={session}>
+              <AppShell>{children}</AppShell>
+            </AuthSessionProvider>
           </ColorModeProvider>
         </AppRouterCacheProvider>
       </body>

--- a/src/features/board-import/application/actions/createBoardImportBatchAction.ts
+++ b/src/features/board-import/application/actions/createBoardImportBatchAction.ts
@@ -13,6 +13,7 @@ import {
   toBoardImportRowDTO,
 } from "@/features/board-import/application/dto/BoardImportDTOMapper";
 import { CreateBoardImportBatchUseCase } from "@/features/board-import/application/usecases/CreateBoardImportBatchUseCase";
+import { requireAuth } from "@/shared/lib/auth/session";
 import { setupDI } from "@/shared/lib/di/container";
 import { container } from "tsyringe";
 
@@ -32,6 +33,7 @@ export interface CreateBoardImportBatchActionOutput {
 export async function createBoardImportBatchAction(
   input: CreateBoardImportBatchActionInput
 ): Promise<CreateBoardImportBatchActionOutput> {
+  const session = await requireAuth();
   setupDI(container);
 
   const useCase = container.resolve(CreateBoardImportBatchUseCase);
@@ -40,7 +42,7 @@ export async function createBoardImportBatchAction(
 
   const result = await useCase.execute({
     municipalityId: input.municipalityId,
-    uploaderId: input.uploaderId?.trim() || null,
+    uploaderId: input.uploaderId?.trim() || session.user.id,
     fileName: input.file.name,
     buffer,
     contentType: input.file.type,

--- a/src/features/board-import/application/actions/getBoardImportBatchDetailAction.ts
+++ b/src/features/board-import/application/actions/getBoardImportBatchDetailAction.ts
@@ -11,6 +11,7 @@ import {
   BoardImportBatchNotFoundError,
   GetBoardImportBatchDetailUseCase,
 } from "@/features/board-import/application/usecases/GetBoardImportBatchDetailUseCase";
+import { requireAuth } from "@/shared/lib/auth/session";
 import { setupDI } from "@/shared/lib/di/container";
 import { container } from "tsyringe";
 
@@ -27,6 +28,7 @@ export interface GetBoardImportBatchDetailActionOutput {
 export async function getBoardImportBatchDetailAction(
   input: GetBoardImportBatchDetailActionInput
 ): Promise<GetBoardImportBatchDetailActionOutput> {
+  await requireAuth();
   setupDI(container);
 
   try {

--- a/src/features/board-import/application/actions/listBoardImportBatchesAction.ts
+++ b/src/features/board-import/application/actions/listBoardImportBatchesAction.ts
@@ -8,6 +8,7 @@ import {
   BOARD_IMPORT_STATUS_VALUES,
   type BoardImportStatus,
 } from "@/features/board-import/domain/types/BoardImportTypes";
+import { requireAuth } from "@/shared/lib/auth/session";
 import { setupDI } from "@/shared/lib/di/container";
 import { container } from "tsyringe";
 
@@ -27,6 +28,7 @@ export interface ListBoardImportBatchesActionOutput {
 export async function listBoardImportBatchesAction(
   input: ListBoardImportBatchesActionInput = {}
 ): Promise<ListBoardImportBatchesActionOutput> {
+  await requireAuth();
   setupDI(container);
 
   const useCase = container.resolve(ListBoardImportBatchesUseCase);

--- a/src/features/board-import/application/actions/updateBoardImportRowDecisionAction.ts
+++ b/src/features/board-import/application/actions/updateBoardImportRowDecisionAction.ts
@@ -8,6 +8,7 @@ import {
   BOARD_IMPORT_ROW_DECISION_VALUES,
   type BoardImportRowDecision,
 } from "@/features/board-import/domain/types/BoardImportTypes";
+import { requireAuth } from "@/shared/lib/auth/session";
 import { setupDI } from "@/shared/lib/di/container";
 import { container } from "tsyringe";
 
@@ -21,6 +22,7 @@ export interface UpdateBoardImportRowDecisionActionInput {
 export async function updateBoardImportRowDecisionAction(
   input: UpdateBoardImportRowDecisionActionInput
 ): Promise<BoardImportRowDTO> {
+  await requireAuth();
   setupDI(container);
 
   const useCase = container.resolve(UpdateBoardImportRowDecisionUseCase);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ import { middlewareAuth } from "@/shared/lib/auth/middleware";
 
 export default middlewareAuth((req) => {
   if (!req.auth) {
-    const signInUrl = new URL("/api/auth/signin", req.nextUrl.origin);
+    const signInUrl = new URL("/auth/signin", req.nextUrl.origin);
     signInUrl.searchParams.set("callbackUrl", req.nextUrl.href);
     return NextResponse.redirect(signInUrl);
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+import { middlewareAuth } from "@/shared/lib/auth/middleware";
+
+export default middlewareAuth((req) => {
+  if (!req.auth) {
+    const signInUrl = new URL("/api/auth/signin", req.nextUrl.origin);
+    signInUrl.searchParams.set("callbackUrl", req.nextUrl.href);
+    return NextResponse.redirect(signInUrl);
+  }
+
+  return NextResponse.next();
+});
+
+export const config = {
+  matcher: ["/board-imports/:path*"],
+};

--- a/src/scripts/create-admin-user.ts
+++ b/src/scripts/create-admin-user.ts
@@ -1,0 +1,65 @@
+import { PrismaClient, UserRole } from "@prisma/client";
+import { hash } from "bcryptjs";
+
+const REQUIRED_ENV = ["ADMIN_EMAIL", "ADMIN_PASSWORD"] as const;
+
+const missing = REQUIRED_ENV.filter(
+  (key) => !process.env[key] || process.env[key]?.trim().length === 0
+);
+
+if (missing.length > 0) {
+  console.error(
+    `Missing required environment variables: ${missing.join(", ")}.\n` +
+      "Set ADMIN_EMAIL / ADMIN_PASSWORD (and optionally ADMIN_NAME) before running this script."
+  );
+  process.exit(1);
+}
+
+const email = process.env.ADMIN_EMAIL!.trim().toLowerCase();
+const rawPassword = process.env.ADMIN_PASSWORD!.trim();
+const displayName =
+  process.env.ADMIN_NAME?.trim() && process.env.ADMIN_NAME.trim().length > 0
+    ? process.env.ADMIN_NAME.trim()
+    : "Polister 管理者";
+
+if (rawPassword.length < 8) {
+  console.error("ADMIN_PASSWORD must be at least 8 characters long.");
+  process.exit(1);
+}
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const passwordHash = await hash(rawPassword, 12);
+  const now = new Date();
+
+  const user = await prisma.user.upsert({
+    where: { email },
+    create: {
+      email,
+      name: displayName,
+      role: UserRole.ADMIN,
+      passwordHash,
+      emailVerified: now,
+    },
+    update: {
+      name: displayName,
+      role: UserRole.ADMIN,
+      passwordHash,
+      emailVerified: now,
+    },
+  });
+
+  console.info(
+    `Admin user ready: ${user.email} (role=${user.role}) — password updated.`
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error("Failed to create admin user:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/shared/lib/auth/config.ts
+++ b/src/shared/lib/auth/config.ts
@@ -1,0 +1,83 @@
+import type { UserRole } from "@prisma/client";
+import type { DefaultSession, NextAuthConfig } from "next-auth";
+import type { JWT } from "next-auth/jwt";
+
+const defaultUserRole: UserRole = "VIEWER";
+
+const getNextAuthSecret = (): string => {
+  const secret = process.env.NEXTAUTH_SECRET;
+
+  if (!secret || secret.trim().length === 0) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(
+        "NEXTAUTH_SECRET is required in production. Please set it in your environment variables."
+      );
+    }
+
+    // 開発環境用のデフォルト値（警告を出す）
+    console.warn(
+      "⚠️  NEXTAUTH_SECRET is not set. Using a default value for development. " +
+        "Please set NEXTAUTH_SECRET in your .env file for production use."
+    );
+    return "development-secret-change-this-in-production";
+  }
+
+  return secret.trim();
+};
+
+const buildSessionUser = (
+  sessionUser: DefaultSession["user"] | undefined,
+  token: JWT
+): DefaultSession["user"] & {
+  id: string;
+  role: UserRole;
+  emailVerified: Date | null;
+} => {
+  const name = token.name ?? sessionUser?.name ?? null;
+  const email: string = (token.email ?? sessionUser?.email ?? "") as string;
+  const image = token.picture ?? sessionUser?.image ?? null;
+  const emailVerified =
+    (sessionUser as { emailVerified?: Date | null } | undefined)
+      ?.emailVerified ?? null;
+
+  return {
+    id: (token.sub ?? "") as string,
+    role: (token.role ?? defaultUserRole) as UserRole,
+    name,
+    email,
+    image,
+    emailVerified,
+  };
+};
+
+export const authConfigBase: NextAuthConfig = {
+  secret: getNextAuthSecret(),
+  providers: [],
+  session: {
+    strategy: "jwt",
+  },
+  trustHost: true,
+  pages: {
+    signIn: "/auth/signin",
+  },
+  callbacks: {
+    jwt({ token, user }) {
+      if (user) {
+        token.role = (user.role ?? defaultUserRole) as UserRole;
+        token.name = user.name ?? token.name;
+        token.email = user.email ?? token.email;
+        token.picture = user.image ?? token.picture;
+      }
+
+      return token;
+    },
+    session({ session, token }) {
+      const enrichedUser = buildSessionUser(session.user, token);
+      session.user = session.user ?? {};
+      Object.assign(session.user, enrichedUser);
+      return session;
+    },
+  },
+};
+
+export const AUTH_DEFAULT_ROLE = defaultUserRole;

--- a/src/shared/lib/auth/index.ts
+++ b/src/shared/lib/auth/index.ts
@@ -1,0 +1,89 @@
+import type { PrismaClient } from "@prisma/client";
+import { compare } from "bcryptjs";
+import NextAuth, { type NextAuthConfig } from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+
+import { AUTH_DEFAULT_ROLE, authConfigBase } from "@/shared/lib/auth/config";
+import { resolve, setupDI, TOKENS } from "@/shared/lib/di";
+
+setupDI();
+
+const prisma = resolve(TOKENS.PrismaClient) as PrismaClient;
+
+const credentialsProvider = Credentials({
+  name: "メールアドレスとパスワード",
+  credentials: {
+    email: {
+      label: "メールアドレス",
+      type: "email",
+      placeholder: "user@example.com",
+    },
+    password: { label: "パスワード", type: "password" },
+  },
+  async authorize(credentials) {
+    const rawEmail =
+      typeof credentials?.email === "string" ? credentials.email : undefined;
+    const rawPassword =
+      typeof credentials?.password === "string"
+        ? credentials.password
+        : undefined;
+
+    const email = rawEmail?.toLowerCase().trim();
+    const password = rawPassword ?? "";
+
+    if (!email || password.length === 0) {
+      return null;
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (!user || !user.passwordHash) {
+      return null;
+    }
+
+    const isValid = await compare(password, user.passwordHash);
+    if (!isValid) {
+      return null;
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role ?? AUTH_DEFAULT_ROLE,
+      emailVerified: user.emailVerified,
+    };
+  },
+});
+
+export const authConfig: NextAuthConfig = {
+  ...authConfigBase,
+  providers: [credentialsProvider],
+  events: {
+    async signIn({ user, account }) {
+      const logger = resolve(TOKENS.Logger);
+      logger.info("ユーザーがサインインしました。", {
+        userId: user.id,
+        provider: account?.provider,
+      });
+    },
+    async signOut(message) {
+      const logger = resolve(TOKENS.Logger);
+      const sessionUserId =
+        "session" in message
+          ? ((message.session as { user?: { id?: string } }).user?.id ?? null)
+          : null;
+      const userId =
+        "token" in message
+          ? (message.token?.sub ?? sessionUserId)
+          : sessionUserId;
+      logger.info("ユーザーがサインアウトしました。", {
+        userId,
+      });
+    },
+  },
+};
+
+export const { auth, handlers, signIn, signOut } = NextAuth(authConfig);

--- a/src/shared/lib/auth/middleware.ts
+++ b/src/shared/lib/auth/middleware.ts
@@ -1,0 +1,5 @@
+import NextAuth from "next-auth";
+
+import { authConfigBase } from "@/shared/lib/auth/config";
+
+export const { auth: middlewareAuth } = NextAuth(authConfigBase);

--- a/src/shared/lib/auth/session.ts
+++ b/src/shared/lib/auth/session.ts
@@ -1,0 +1,15 @@
+import type { Session } from "next-auth";
+
+import { UnauthorizedError } from "@/shared/errors/application-error";
+
+import { auth } from "./index";
+
+export const requireAuth = async (): Promise<Session> => {
+  const session = await auth();
+
+  if (!session) {
+    throw new UnauthorizedError();
+  }
+
+  return session;
+};

--- a/src/shared/types/next-auth.d.ts
+++ b/src/shared/types/next-auth.d.ts
@@ -1,0 +1,22 @@
+import type { UserRole } from "@prisma/client";
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: DefaultSession["user"] & {
+      id: string;
+      role: UserRole;
+      emailVerified: Date | null;
+    };
+  }
+
+  interface User {
+    role: UserRole;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: UserRole;
+  }
+}

--- a/src/shared/ui/components/layout/AppBar.tsx
+++ b/src/shared/ui/components/layout/AppBar.tsx
@@ -7,6 +7,7 @@
 import {
   Box,
   Button,
+  CircularProgress,
   Container,
   AppBar as MuiAppBar,
   Stack,
@@ -14,8 +15,10 @@ import {
   Typography,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
 
 import { APP_BAR_HEIGHT } from "@/shared/constants/layout";
 
@@ -28,17 +31,25 @@ const NAV_ITEMS = [
   { label: "都道府県一覧", path: "/prefectures" },
 ];
 
-const DEFAULT_USER = {
-  name: "運営チーム",
-  email: "team@polister.local",
-};
-
 export function AppBar() {
   const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data: session, status } = useSession();
+  const isAuthenticated = status === "authenticated";
+  const isLoading = status === "loading";
 
   const docsUrl =
     process.env.NEXT_PUBLIC_DOCS_URL ??
     "https://team-mirai-volunteer.github.io/polister/";
+
+  const handleSignIn = useCallback(() => {
+    const search = searchParams.toString();
+    const currentPath = pathname ?? "/";
+    const callbackSource = search ? `${currentPath}?${search}` : currentPath;
+    const callback = encodeURIComponent(callbackSource);
+    router.push(`/auth/signin?callbackUrl=${callback}`);
+  }, [pathname, router, searchParams]);
 
   return (
     <MuiAppBar position="fixed">
@@ -183,7 +194,24 @@ export function AppBar() {
               ドキュメント
             </Button>
             <ColorModeToggle />
-            <UserMenu user={DEFAULT_USER} />
+            {isAuthenticated && session?.user ? (
+              <UserMenu user={session.user} />
+            ) : isLoading ? (
+              <CircularProgress
+                size={20}
+                aria-label="認証状態を確認中"
+                color="inherit"
+              />
+            ) : (
+              <Button
+                variant="contained"
+                size="small"
+                onClick={handleSignIn}
+                sx={{ fontWeight: 600 }}
+              >
+                ログイン
+              </Button>
+            )}
           </Stack>
         </Container>
       </Toolbar>

--- a/src/shared/ui/components/layout/UserMenu.tsx
+++ b/src/shared/ui/components/layout/UserMenu.tsx
@@ -13,19 +13,29 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
+import type { UserRole } from "@prisma/client";
+import { signOut } from "next-auth/react";
 import { useMemo, useState } from "react";
 
 interface UserInfo {
-  name: string;
-  email?: string;
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  role?: UserRole;
 }
 
 interface UserMenuProps {
   user: UserInfo;
 }
 
-const getInitials = (name: string): string => {
-  const parts = name.trim().split(/\s+/);
+const getInitials = (name?: string | null, email?: string | null): string => {
+  if (!name && email) {
+    return email.slice(0, 2).toUpperCase();
+  }
+
+  const safeName = name ?? "";
+  const parts = safeName.trim().split(/\s+/);
   if (parts.length === 0) {
     return "U";
   }
@@ -42,7 +52,11 @@ export function UserMenu({ user }: UserMenuProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
-  const initials = useMemo(() => getInitials(user.name), [user.name]);
+  const initials = useMemo(
+    () => getInitials(user.name, user.email),
+    [user.email, user.name]
+  );
+  const displayName = user.name ?? user.email ?? "ログインユーザー";
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -65,6 +79,7 @@ export function UserMenu({ user }: UserMenuProps) {
           aria-expanded={open ? "true" : undefined}
         >
           <Avatar
+            src={user.image ?? undefined}
             sx={{
               width: 32,
               height: 32,
@@ -97,23 +112,32 @@ export function UserMenu({ user }: UserMenuProps) {
           </ListItemIcon>
           <div>
             <Typography variant="body2" fontWeight={600}>
-              {user.name}
+              {displayName}
             </Typography>
             {user.email && (
               <Typography variant="caption" color="text.secondary">
                 {user.email}
               </Typography>
             )}
+            {user.role && (
+              <Typography variant="caption" color="text.secondary">
+                ロール: {user.role}
+              </Typography>
+            )}
           </div>
         </MenuItem>
         <Divider sx={{ my: 1 }} />
-        <MenuItem>
+        <MenuItem disabled>
           <ListItemIcon>
             <ManageAccountsIcon fontSize="small" />
           </ListItemIcon>
-          プロフィール設定
+          プロフィール設定（準備中）
         </MenuItem>
-        <MenuItem>
+        <MenuItem
+          onClick={() => {
+            void signOut({ callbackUrl: "/" });
+          }}
+        >
           <ListItemIcon>
             <LogoutIcon fontSize="small" />
           </ListItemIcon>

--- a/src/shared/ui/providers/AuthSessionProvider.tsx
+++ b/src/shared/ui/providers/AuthSessionProvider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import type { Session } from "next-auth";
+import { SessionProvider } from "next-auth/react";
+
+interface AuthSessionProviderProps {
+  session: Session | null;
+  children: React.ReactNode;
+}
+
+export function AuthSessionProvider({
+  session,
+  children,
+}: AuthSessionProviderProps) {
+  return <SessionProvider session={session}>{children}</SessionProvider>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,17 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
+"@auth/core@0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@auth/core/-/core-0.41.0.tgz#6a57e18ab0dd0fc2606f9f0f7460a67190966161"
+  integrity sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==
+  dependencies:
+    "@panva/hkdf" "^1.2.1"
+    jose "^6.0.6"
+    oauth4webapi "^3.3.0"
+    preact "10.24.3"
+    preact-render-to-string "6.5.11"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
@@ -1411,6 +1422,11 @@
   version "1.0.39"
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
+
+"@panva/hkdf@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@panva/hkdf/-/hkdf-1.2.1.tgz#cb0d111ef700136f4580349ff0226bf25c853f23"
+  integrity sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -3789,6 +3805,11 @@ baseline-browser-mapping@^2.8.3:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.8.tgz#ca0de7b23bf9c49d72e21dcbfba26f2bb223ea2e"
   integrity sha512-be0PUaPsQX/gPWWgFsdD+GFzaoig5PXaUC1xLkQiYdDnANU8sMnHoQd8JhbJQuvTWrWLyeFN9Imb5Qtfvr4RrQ==
 
+bcryptjs@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-3.0.2.tgz#caadcca1afefe372ed6e20f86db8e8546361c1ca"
+  integrity sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==
+
 bignumber.js@^9.1.0:
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
@@ -6083,6 +6104,11 @@ jiti@^2.4.2:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.0.tgz#b831fdc4440c0a4944c34456643c555afe09d36d"
   integrity sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==
 
+jose@^6.0.6:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.1.0.tgz#96285365689d16f2845a353964d2284bf19f464c"
+  integrity sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6419,6 +6445,13 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+next-auth@5.0.0-beta.30:
+  version "5.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-5.0.0-beta.30.tgz#945af66d27d2e6defa34a4d96765df67fe4164cc"
+  integrity sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==
+  dependencies:
+    "@auth/core" "0.41.0"
+
 next@15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/next/-/next-15.5.4.tgz#e7412c805c0b686ceaf294de703b7c9be59a4081"
@@ -6482,6 +6515,11 @@ nypm@^0.6.0:
     pathe "^2.0.3"
     pkg-types "^2.3.0"
     tinyexec "^1.0.1"
+
+oauth4webapi@^3.3.0:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/oauth4webapi/-/oauth4webapi-3.8.2.tgz#500d1979038c14656f3f24ff1eb501ff3993115b"
+  integrity sha512-FzZZ+bht5X0FKe7Mwz3DAVAmlH1BV5blSak/lHMBKz0/EBMhX6B10GlQYI51+oRp8ObJaX0g6pXrAxZh5s8rjw==
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -6797,6 +6835,16 @@ potpack@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/potpack/-/potpack-2.1.0.tgz#fe548e2f9061e9937f17191c1ab6dd98ca30e02f"
   integrity sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==
+
+preact-render-to-string@6.5.11:
+  version "6.5.11"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz#467e69908a453497bb93d4d1fc35fb749a78e027"
+  integrity sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==
+
+preact@10.24.3:
+  version "10.24.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.24.3.tgz#086386bd47071e3b45410ef20844c21e23828f64"
+  integrity sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## 変更の概要

NextAuth.js v5を使用したユーザー認証基盤（Credentials認証）を実装しました。メールアドレスとパスワードによるログイン機能、セッション管理、認証ミドルウェア、初期管理者作成フローを含む、完全な認証システムです。

## 変更の背景

MVPフェーズでは内部運用を優先するため、Google OAuth連携よりも手元で管理しやすいCredentials認証を実装しました。掲示板インポート機能などの重要な操作に認証が必要となるため、認証基盤の整備が必須となりました。

## 関連Issue

Closes #23

## 変更内容

### 認証基盤
- [x] NextAuth.js v5とbcryptjsの導入
- [x] Credentials認証プロバイダーの実装（メールアドレス＋パスワード）
- [x] JWT戦略によるセッション管理
- [x] Edge Runtime対応の認証ミドルウェア（/board-imports/*を保護）

### データベース
- [x] Prisma schema: User.passwordHashカラム追加
- [x] 初期管理者作成スクリプト（yarn user:create-admin）

### UI実装
- [x] ログイン画面とフォーム（/auth/signin）
- [x] AppBar/UserMenuの認証連携（サインイン/サインアウトボタン）
- [x] AuthSessionProviderによるクライアント側セッション管理

### セキュリティ
- [x] BoardImport系アクションに認証チェック追加（requireAuth）
- [x] ミドルウェアによる未認証アクセス制御
- [x] NEXTAUTH_SECRET環境変数のフォールバック処理（開発/本番対応）

### ドキュメント
- [x] README.md: 認証セットアップ手順を追加
- [x] .env.example: 認証関連の環境変数を追加
- [x] 実行計画（docs/docs/plan/23_user-auth-nextauth.md）

## テスト

- [x] ローカルでの動作確認
- [x] yarn typecheck: 成功
- [x] yarn lint: 成功
- [x] yarn format:check: 成功
- [x] yarn test:coverage: 成功（74テスト全て通過）
- [x] 初期管理者作成スクリプトの動作確認
- [x] ログイン/ログアウトフローの動作確認

## CLAへの同意

このプロジェクトへの貢献には、[Contributor License Agreement (CLA)](https://github.com/team-mirai-volunteer/polister/blob/develop/CLA.md) への同意が必要です。

- [x] [CLA](https://github.com/team-mirai-volunteer/polister/blob/develop/CLA.md)の内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メール／パスワードによるサインイン画面と認証フローを追加しました
  * 初期管理者を作成するスクリプトと実行コマンドを追加しました
  * 認証に応じたナビバーのユーザーメニューとログアウト動作を追加しました
  * 特定ページを保護する認証ミドルウェアとセッションプロバイダーを導入しました

* **ドキュメント**
  * READMEに.env設定手順（管理者作成含む）を追記しました
  * 認証導入計画書を追加しました

* **変更**
  * ユーザーデータにパスワードハッシュ用フィールドを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->