### PR TITLE
fix: 掲示板番号文字列化の追加修正とNext.js 15対応

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,7 @@ const eslintConfig = [
       "docs/.docusaurus/**",
       "docs/build/**",
       "**/coverage/**",
+      "tmp/**",
     ],
   },
 ];

--- a/src/app/board-imports/[batchId]/page.tsx
+++ b/src/app/board-imports/[batchId]/page.tsx
@@ -24,9 +24,11 @@ interface BoardImportDetailPageProps {
 export default async function BoardImportDetailPage({
   params,
 }: BoardImportDetailPageProps) {
+  const { batchId } = await params;
+
   try {
     const { batch, rows } = await getBoardImportBatchDetailAction({
-      batchId: params.batchId,
+      batchId,
     });
 
     return (
@@ -69,7 +71,7 @@ export default async function BoardImportDetailPage({
     }
 
     console.error(
-      `[BoardImportDetailPage] Failed to load batch ${params.batchId}:`,
+      `[BoardImportDetailPage] Failed to load batch ${batchId}:`,
       error
     );
     throw error;

--- a/src/features/municipality/infrastructure/repositories/MunicipalityRepository.ts
+++ b/src/features/municipality/infrastructure/repositories/MunicipalityRepository.ts
@@ -204,7 +204,7 @@ export class MunicipalityRepository implements IMunicipalityRepository {
     >`
       SELECT
         id,
-        board_number,
+        board_number::text AS board_number,
         name,
         address,
         ST_X(location::geometry) AS longitude,
@@ -216,18 +216,18 @@ export class MunicipalityRepository implements IMunicipalityRepository {
         AND deleted_at IS NULL
       ORDER BY
         CASE
-          WHEN board_number ~ '^\d+(-\d+)?$' THEN (
-            split_part(board_number, '-', 1)::int
+          WHEN board_number::text ~ '^\d+(-\d+)?$' THEN (
+            split_part(board_number::text, '-', 1)::int
           )
           ELSE NULL
         END ASC NULLS LAST,
         CASE
-          WHEN board_number ~ '^\d+-\d+$' THEN (
-            split_part(board_number, '-', 2)::int
+          WHEN board_number::text ~ '^\d+-\d+$' THEN (
+            split_part(board_number::text, '-', 2)::int
           )
           ELSE NULL
         END ASC NULLS LAST,
-        board_number ASC NULLS LAST,
+        board_number::text ASC NULLS LAST,
         created_at ASC
     `;
 


### PR DESCRIPTION
## 概要

Issue #78で実施した掲示板番号の文字列化に伴う追加修正と、Next.js 15の仕様変更への対応を実施しました。

## 変更内容

### 1. PostgreSQLクエリの型キャスト追加
- **問題**: 掲示板番号を数値→文字列に変更後、PostgreSQLのキャッシュされた実行プランと型が不一致でエラー発生
- **解決**: `MunicipalityRepository.ts`のクエリで`board_number::text`キャストを追加
- **影響**: 自治体詳細ページで掲示板一覧が正常に表示されるようになった

### 2. Next.js 15のparams await対応
- **問題**: Next.js 15で動的ルートの`params`が非同期になった
- **解決**: `board-imports/[batchId]/page.tsx`で`params`を使用前に`await`
- **影響**: インポートバッチ詳細ページのwarningが解消

### 3. ESLint設定の改善
- tmpディレクトリをignoresに追加し、一時ファイルのlintエラーを回避

## テスト

- ✅ `yarn typecheck` - 型チェック通過
- ✅ `yarn lint` - ESLint通過
- ✅ `yarn format:check` - フォーマットチェック通過

## 関連Issue

- #78 掲示板番号を文字列型に変更する（フォローアップ修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **修正**
  * ボード番号の処理と並び順の処理を改善し、一貫性を向上させました。

* **その他の改善**
  * 開発環境の設定を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->