### PR TITLE
refactor: Server Actionsのログ出力をloggerに統一

### DIFF
--- a/src/features/board-image/application/actions/deleteBoardImageAction.ts
+++ b/src/features/board-image/application/actions/deleteBoardImageAction.ts
@@ -4,6 +4,7 @@ import "reflect-metadata";
 
 import { resolve } from "@/shared/lib/di";
 import { TOKENS } from "@/shared/lib/di/tokens";
+import { logger } from "@/shared/logging/logger";
 
 interface DeleteBoardImageResult {
   success: boolean;
@@ -32,7 +33,7 @@ export async function deleteBoardImageAction(
       try {
         await storageService.delete(filePath);
       } catch (error) {
-        console.warn("画像ファイル削除失敗", filePath, error);
+        logger.warn("画像ファイル削除失敗", filePath, error);
       }
     })
   );

--- a/src/features/board-image/application/actions/updateBoardImageAction.ts
+++ b/src/features/board-image/application/actions/updateBoardImageAction.ts
@@ -2,6 +2,7 @@
 
 import { resolve } from "@/shared/lib/di";
 import { TOKENS } from "@/shared/lib/di/tokens";
+import { logger } from "@/shared/logging/logger";
 import { revalidatePath } from "next/cache";
 
 export type ImageAction =
@@ -113,7 +114,7 @@ export async function updateBoardImageAction(
       message: "更新しました",
     };
   } catch (error) {
-    console.error("updateBoardImageAction error:", error);
+    logger.error("updateBoardImageAction error:", error);
     return {
       success: false,
       message: error instanceof Error ? error.message : "更新に失敗しました",

--- a/src/features/board-image/application/actions/updateBoardNumberAction.ts
+++ b/src/features/board-image/application/actions/updateBoardNumberAction.ts
@@ -2,6 +2,7 @@
 
 import { resolve } from "@/shared/lib/di";
 import { TOKENS } from "@/shared/lib/di/tokens";
+import { logger } from "@/shared/logging/logger";
 import { revalidatePath } from "next/cache";
 
 export async function updateBoardNumberAction(
@@ -24,7 +25,7 @@ export async function updateBoardNumberAction(
       message: "掲示場番号を更新しました",
     };
   } catch (error) {
-    console.error("updateBoardNumberAction error:", error);
+    logger.error("updateBoardNumberAction error:", error);
     return {
       success: false,
       message: error instanceof Error ? error.message : "更新に失敗しました",

--- a/src/features/board-import/application/actions/deleteBoardImportBatchAction.ts
+++ b/src/features/board-import/application/actions/deleteBoardImportBatchAction.ts
@@ -5,6 +5,7 @@ import "reflect-metadata";
 import { DeleteBoardImportBatchUseCase } from "@/features/board-import/application/usecases/DeleteBoardImportBatchUseCase";
 import { BoardImportBatchNotFoundError } from "@/features/board-import/application/usecases/GetBoardImportBatchDetailUseCase";
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 
 interface DeleteBoardImportBatchInput {
@@ -26,7 +27,7 @@ export async function deleteBoardImportBatchAction(
     await useCase.execute({ batchId: input.batchId });
     return { success: true };
   } catch (error) {
-    console.error("[deleteBoardImportBatchAction] Failed", error);
+    logger.error("[deleteBoardImportBatchAction] Failed", error);
 
     if (error instanceof BoardImportBatchNotFoundError) {
       return { success: false, error: "not_found" };

--- a/src/features/board-import/application/actions/getBoardImportBatchDetailAction.ts
+++ b/src/features/board-import/application/actions/getBoardImportBatchDetailAction.ts
@@ -12,6 +12,7 @@ import {
   GetBoardImportBatchDetailUseCase,
 } from "@/features/board-import/application/usecases/GetBoardImportBatchDetailUseCase";
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 
 export interface GetBoardImportBatchDetailActionInput {
@@ -34,7 +35,7 @@ export async function getBoardImportBatchDetailAction(
 
     return await useCase.execute({ batchId: input.batchId });
   } catch (error) {
-    console.error(
+    logger.error(
       "[getBoardImportBatchDetailAction] Failed to load batch detail",
       error
     );

--- a/src/features/board/application/actions/getBoardLocationsAction.ts
+++ b/src/features/board/application/actions/getBoardLocationsAction.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 
 import {
@@ -21,7 +22,7 @@ export async function getBoardLocationsAction(
     const useCase = container.resolve(GetBoardLocationsUseCase);
     return await useCase.execute(input);
   } catch (error) {
-    console.error("Error in getBoardLocationsAction:", error);
+    logger.error("Error in getBoardLocationsAction:", error);
     throw new Error("掲示場位置情報の取得に失敗しました", { cause: error });
   }
 }

--- a/src/features/municipality/application/actions/getMunicipalitiesAction.ts
+++ b/src/features/municipality/application/actions/getMunicipalitiesAction.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 import {
   MUNICIPALITY_FIELD_OPERATORS,
@@ -114,7 +115,7 @@ export async function getMunicipalitiesAction(
       limit: result.limit,
     };
   } catch (error) {
-    console.error("Error in getMunicipalitiesAction:", error);
+    logger.error("Error in getMunicipalitiesAction:", error);
     throw new Error("自治体一覧の取得に失敗しました");
   }
 }

--- a/src/features/municipality/application/actions/getMunicipalityBoardsAction.ts
+++ b/src/features/municipality/application/actions/getMunicipalityBoardsAction.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 import type { MunicipalityBoardDTO } from "../dto/MunicipalityBoardDTO";
 import { GetMunicipalityBoardsUseCase } from "../usecases/GetMunicipalityBoardsUseCase";
@@ -23,7 +24,7 @@ export async function getMunicipalityBoardsAction(
     const useCase = container.resolve(GetMunicipalityBoardsUseCase);
     return await useCase.execute(normalizedId);
   } catch (error) {
-    console.error(
+    logger.error(
       `Error in getMunicipalityBoardsAction(${municipalityId}):`,
       error
     );

--- a/src/features/municipality/application/actions/getMunicipalityByIdAction.ts
+++ b/src/features/municipality/application/actions/getMunicipalityByIdAction.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 import { MunicipalityMapper } from "../../infrastructure/mappers/MunicipalityMapper";
 import { GetMunicipalityByIdUseCase } from "../usecases/GetMunicipalityByIdUseCase";
@@ -24,7 +25,7 @@ export async function getMunicipalityByIdAction(id: string) {
     // DTOに変換して返す
     return MunicipalityMapper.toDTO(municipality);
   } catch (error) {
-    console.error(`Error in getMunicipalityByIdAction(${id}):`, error);
+    logger.error(`Error in getMunicipalityByIdAction(${id}):`, error);
     throw new Error("自治体詳細の取得に失敗しました");
   }
 }

--- a/src/features/municipality/application/actions/getMunicipalityGeoJSONAction.ts
+++ b/src/features/municipality/application/actions/getMunicipalityGeoJSONAction.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 import { ExportMunicipalityGeoJSONUseCase } from "../usecases/ExportMunicipalityGeoJSONUseCase";
 
@@ -22,7 +23,7 @@ export async function getMunicipalityGeoJSONAction(id: string) {
 
     return geojson;
   } catch (error) {
-    console.error(`Error in getMunicipalityGeoJSONAction(${id}):`, error);
+    logger.error(`Error in getMunicipalityGeoJSONAction(${id}):`, error);
     throw new Error("自治体GeoJSONの取得に失敗しました");
   }
 }

--- a/src/features/prefecture/application/actions/getPrefectureByCodeAction.ts
+++ b/src/features/prefecture/application/actions/getPrefectureByCodeAction.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 
 import { PrefectureMapper } from "../../infrastructure/mappers/PrefectureMapper";
@@ -27,7 +28,7 @@ export async function getPrefectureByCodeAction(code: string) {
 
     return PrefectureMapper.toDetailDTO(prefecture);
   } catch (error) {
-    console.error("Error in getPrefectureByCodeAction:", error);
+    logger.error("Error in getPrefectureByCodeAction:", error);
     throw new Error("都道府県詳細の取得に失敗しました", { cause: error });
   }
 }

--- a/src/features/prefecture/application/actions/getPrefecturesAction.ts
+++ b/src/features/prefecture/application/actions/getPrefecturesAction.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 
 import {
@@ -112,7 +113,7 @@ export async function getPrefecturesAction(params: GetPrefecturesParams = {}) {
 
     return prefectures.map((prefecture) => PrefectureMapper.toDTO(prefecture));
   } catch (error) {
-    console.error("Error in getPrefecturesAction:", error);
+    logger.error("Error in getPrefecturesAction:", error);
     throw new Error("都道府県一覧の取得に失敗しました", { cause: error });
   }
 }

--- a/src/features/statistics/application/actions/getSystemMetricsAction.ts
+++ b/src/features/statistics/application/actions/getSystemMetricsAction.ts
@@ -5,6 +5,7 @@
 "use server";
 
 import { setupDI } from "@/shared/lib/di/container";
+import { logger } from "@/shared/logging/logger";
 import { container } from "tsyringe";
 
 import { GetSystemMetricsUseCase } from "../usecases/GetSystemMetricsUseCase";
@@ -29,12 +30,12 @@ export async function getSystemMetricsAction(): Promise<SystemMetricsResult> {
     };
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.error("Error in getSystemMetricsAction:", {
+      logger.error("Error in getSystemMetricsAction:", {
         message: error.message,
         stack: error.stack,
       });
     } else {
-      console.error("Error in getSystemMetricsAction:", error);
+      logger.error("Error in getSystemMetricsAction:", error);
     }
     return {
       municipalities: 0,


### PR DESCRIPTION
## 概要

Server Actions（13ファイル）の`console.error/warn`を共通の`logger`ユーティリティに置き換え、ログ出力を統一しました。

## 変更内容

### 変更対象ファイル（13ファイル）

| コンテキスト | ファイル |
|-------------|----------|
| board-image | `deleteBoardImageAction.ts`, `updateBoardImageAction.ts`, `updateBoardNumberAction.ts` |
| board-import | `deleteBoardImportBatchAction.ts`, `getBoardImportBatchDetailAction.ts` |
| board | `getBoardLocationsAction.ts` |
| municipality | `getMunicipalitiesAction.ts`, `getMunicipalityBoardsAction.ts`, `getMunicipalityByIdAction.ts`, `getMunicipalityGeoJSONAction.ts` |
| prefecture | `getPrefectureByCodeAction.ts`, `getPrefecturesAction.ts` |
| statistics | `getSystemMetricsAction.ts` |

### 置換内容
- `console.error(...)` → `logger.error(...)`
- `console.warn(...)` → `logger.warn(...)`

### メリット
- 統一されたログフォーマット
- 将来的なログ設定の一元管理が可能
- 環境ごとのログレベル制御が容易

## テスト

```bash
yarn validate  # typecheck + lint + format:check 全て通過
yarn test:coverage  # 14 suites, 121 tests 全て通過
```

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)