### PR TITLE
fix: Jest設定でnext/jest.jsを明示して解決失敗を回避

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from "jest";
 
-import nextJest from "next/jest";
+import nextJest from "next/jest.js";
 
 const createJestConfig = nextJest({
   dir: "./",


### PR DESCRIPTION
## 変更の概要
Jest 設定で参照している Next.js の Jest ヘルパーの import を **実体ファイルに明示**し、環境によって `next/jest` の解決が失敗するケースを回避します。

- `import nextJest from "next/jest";`
  → `import nextJest from "next/jest.js";`

## 背景 / 現象
特定の実行環境で `yarn validate`（Jest 実行）時に Jest 設定の読み込みで失敗しました。

- エラー: `ERR_MODULE_NOT_FOUND: next/jest`
- 付随メッセージ: `Did you mean to import "next/jest.js"?`

発生環境（確認できた例）:
- OS: Ubuntu 24.04 (WSL2)
- Node: v22.22.0 (nvm)
- Yarn: 1.22.22 (corepack)

再現手順（例）:
1. `yarn install`
2. `yarn validate`（または `yarn test:coverage`）
3. `jest.config.ts` 読み込み時に上記エラーが発生

※ 本件では `next/jest` が解決できず、エラーメッセージ側で `next/jest.js` の利用が示唆されています。  
そのため import を `next/jest.js` に明示し、Node のモジュール解決差分に依存しない形にします。

## なぜこの変更で壊れにくいか（互換性）
本変更は Jest の設定生成ロジック自体には触れず、**import の参照先を明示**して解決経路のみを安定化します。

- `next/jest.js` は Next.js が提供する Jest ヘルパーであり、今回の変更は参照先を **明示**するだけです
- `nextJest({ dir: "./" })` の呼び出し、オプション、生成される Jest config 生成ロジックは不変です
- 変更の主な影響は「特定環境での解決失敗を抑止する」点で、差分は 1 行に限定しています

## 変更内容
- `jest.config.ts` の import を `next/jest` → `next/jest.js` に変更（1行）

## 確認
- `yarn typecheck` ✅
- `yarn lint` ✅
- `yarn format:check` ✅
- `yarn test:coverage` ✅
- `yarn test:e2e` は本件スコープ外

Closes #90

---
English summary:
Import `next/jest.js` explicitly to stabilize module resolution.
Prevents `ERR_MODULE_NOT_FOUND: next/jest` on some environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Jest設定ファイルのモジュール解決を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->